### PR TITLE
RDKEMW-14199: Moving AuthServiceHost configuration to the product layers

### DIFF
--- a/classes/authservice-config.bbclass
+++ b/classes/authservice-config.bbclass
@@ -1,32 +1,47 @@
-# Creates /etc/authservice/config.json configuration file
-# for authentication services with PARTNER_ID configuration
+# AuthService configuration at image assembly time (ROOTFS_POSTPROCESS_COMMAND).
 #
-# Field values should be configured in product layer via BUILTIN_PARTNER_ID
+# 1. Creates /etc/authservice/config.json with BUILTIN_PARTNER_ID
+# 2. Stamps /etc/rfcdefaults/authservice.ini with AuthServiceHost
+#
+# Both values should be configured in product layers.
 
-python create_authservice_config(){
+python create_authservice_config() {
     import json
     import os
 
-    # Get PARTNER_ID directly from product configuration  
-    partner_id = d.getVar("BUILTIN_PARTNER_ID", True)
-    if not partner_id:
-        bb.note("BUILTIN_PARTNER_ID not defined - device will resolve PARTNER_ID at runtime")
+    rootfs = d.getVar("IMAGE_ROOTFS")
+
+    # --- Part 1: /etc/authservice/config.json (PARTNER_ID) ---
+    partner_id = d.getVar("BUILTIN_PARTNER_ID")
+    if partner_id:
+        build_path = os.path.join(rootfs, "etc", "authservice")
+        os.makedirs(build_path, exist_ok=True)
+        config_path = os.path.join(build_path, "config.json")
+        with open(config_path, "w", encoding="utf-8") as f:
+            json.dump({"partner_id": partner_id}, f, indent=2)
+        os.chmod(config_path, 0o644)
+
+    # --- Part 2: /etc/rfcdefaults/authservice.ini (AuthServiceHost) ---
+    auth_host = d.getVar("AuthServiceHost")
+    if not auth_host:
         return
-    
-    config = {
-        "partner_id": "%s" % partner_id
-    }
 
-    # Ensure the directory exists
-    rootfs_dir = d.getVar("IMAGE_ROOTFS", True)
-    build_path = os.path.join(rootfs_dir, "etc", "authservice")
-    os.makedirs(build_path, exist_ok=True)
+    ini_path = os.path.join(rootfs, "etc", "rfcdefaults", "authservice.ini")
+    if not os.path.exists(ini_path):
+        bb.warn("authservice.ini not found at %s" % ini_path)
+        return
 
-    # Write the JSON file
-    config_path = os.path.join(build_path, "config.json")
-    with open(config_path, "w") as json_file:
-        json.dump(config, json_file, indent=2)
-    os.chmod(config_path, 0o644)
+    with open(ini_path, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+
+    prefix = "Device.DeviceInfo.X_RDKCENTRAL-COM_RFC.AuthService.Host="
+    with open(ini_path, "w", encoding="utf-8") as f:
+        for line in lines:
+            if line.startswith(prefix):
+                f.write("%s%s\n" % (prefix, auth_host))
+            else:
+                f.write(line)
+    os.chmod(ini_path, 0o644)
 }
 create_authservice_config[vardepsexclude] += "DATETIME"
 ROOTFS_POSTPROCESS_COMMAND += 'create_authservice_config; '

--- a/conf/include/image-classes.inc
+++ b/conf/include/image-classes.inc
@@ -10,8 +10,7 @@ IMAGE_CLASSES += "aimigrationoverrideconfig"
 
 # /etc/ripple/rdke/northamerica/ripple.config.json
 IMAGE_CLASSES += "ripplemigrationoverrideconfig"
-# Install:
-#  /etc/authservice/config.json
+# /etc/authservice/config.json + /etc/rfcdefaults/authservice.ini
 IMAGE_CLASSES += "authservice-config"
 
 # /etc/migration/boot_FSR.platform


### PR DESCRIPTION
Port of #53 (develop) onto release/8.6.3.0 for the 8.6.3.0 integration (RDKEMW-14199). Same diff, verified clean apply.

Reason for change: AuthServiceHost (XACS URL) is currently defined in region configs and stamped at build time. Moving it to product layers enables per-device control and aligns with the FKPS migration (RDK-48642).

Test Procedure: described in the ticket
Implements: recipe changes
Risks: No
Source: COMCAST
License: Apache-2.0
Upstream-Status: Pending
